### PR TITLE
Add a monoid instance for Success a.

### DIFF
--- a/src/Data/Zero.hs
+++ b/src/Data/Zero.hs
@@ -76,6 +76,10 @@ instance (Semigroup a) => Semigroup (Success a) where
   Success (Just a) <> Success (Just b) = Success . Just $ a <> b
   _ <> _ = zero
 
+instance (Semigroup a, Monoid a) => Monoid (Success a) where
+  mempty = success mempty
+  mappend = (<>)
+
 instance (Semigroup a) => Zero (Success a) where
   zero = Success Nothing
 


### PR DESCRIPTION
When `a` is a monoid, `Success a` also is, with `mempty = success mempty`.
